### PR TITLE
Remove extra COOKIE header from the gmail profile

### DIFF
--- a/normal/gmail.profile
+++ b/normal/gmail.profile
@@ -32,8 +32,6 @@ http-get {
 		header "Accept-Language" "en-US,en;q=0.5";
 		header "Accept-Encoding" "gzip, deflate";
 		header "DNT" "1";
-		header "Cookie" "GMAIL_RTT=265;";
-
 	}
 
 	server {


### PR DESCRIPTION
When using the gmail profile we found that the extra `COOKIE` header caused issues (ie. base64 decoding errors). My guess is that CS expects the first `COOKIE` value to be the value that contains magic content that needs to be base64-decoded.

Removing this extra header made the problem go away.